### PR TITLE
Fix: binary field truncated at 64 bytes

### DIFF
--- a/src/MsgReader.js
+++ b/src/MsgReader.js
@@ -324,8 +324,7 @@ var extractorFieldValue = {
       },
       'binary': function extractBatBinary(ds, msgData, blockStartOffset, bigBlockOffset, blockSize) {
         ds.seek(blockStartOffset + bigBlockOffset);
-        var toReadLength = Math.min(Math.min(msgData.bigBlockSize - bigBlockOffset, blockSize), CONST.MSG.SMALL_BLOCK_SIZE);
-        return ds.readUint8Array(toReadLength);
+        return ds.readUint8Array(blockSize);
       }
     }
   },


### PR DESCRIPTION
This comes directly from https://github.com/ykarpovich/msg.reader/pull/7 .  It appears this fork was created before this correction was made to the original msg.reader.  I am not familiar with this file format, so I can't vouch for it's correctness, but the original PR has a brief description.